### PR TITLE
README: missing command in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Originally at https://carbondoomsday.com/ now hosted at https://carbon.datahub.i
 
 ```
 git clone https://github.com/datahq/carbondoomsday
+cd carbondoomsday
 git submodule init
 git submodule update
 ```


### PR DESCRIPTION
Add a missing `cd' command to make the instructions even more easy to follow.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>